### PR TITLE
missing definitions in triangle.h

### DIFF
--- a/triangle.h
+++ b/triangle.h
@@ -248,6 +248,12 @@
 /*                                                                           */
 /*****************************************************************************/
 
+#ifdef SINGLE
+#define REAL float
+#else /* not SINGLE */
+#define REAL double
+#endif /* not SINGLE */
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/triangle.h
+++ b/triangle.h
@@ -254,6 +254,8 @@
 #define REAL double
 #endif /* not SINGLE */
 
+#define VOID int
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
the include file is needed by PETSc, but the definition of REAL and VOID is missing
Also, I hope that using void is not an issue in 2020